### PR TITLE
Open up TransportationResult and CommunicatorResponse types

### DIFF
--- a/Endpoints.xcodeproj/project.pbxproj
+++ b/Endpoints.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		F438657922B22DCA001E50BE /* CommunicatorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F438657822B22DCA001E50BE /* CommunicatorResponse.swift */; };
+		F438657B22B22DD9001E50BE /* TransportationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F438657A22B22DD9001E50BE /* TransportationResult.swift */; };
 		F4CA9F3B2281C997000CD820 /* Endpoints.h in Headers */ = {isa = PBXBuildFile; fileRef = F4CA9F392281C997000CD820 /* Endpoints.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F4CA9F412281CDA0000CD820 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CA9F402281CDA0000CD820 /* Endpoint.swift */; };
 		F4CA9F432281CE52000CD820 /* DataPacker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CA9F422281CE52000CD820 /* DataPacker.swift */; };
@@ -22,6 +24,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		F438657822B22DCA001E50BE /* CommunicatorResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommunicatorResponse.swift; sourceTree = "<group>"; };
+		F438657A22B22DD9001E50BE /* TransportationResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransportationResult.swift; sourceTree = "<group>"; };
 		F4CA9F362281C997000CD820 /* Endpoints.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Endpoints.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4CA9F392281C997000CD820 /* Endpoints.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Endpoints.h; sourceTree = "<group>"; };
 		F4CA9F3A2281C997000CD820 /* Info-iOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-iOS.plist"; sourceTree = "<group>"; };
@@ -80,6 +84,7 @@
 			children = (
 				F4CA9F4F2281D429000CD820 /* APICommunicator.swift */,
 				F4CA9F4B2281D0D9000CD820 /* Communicator.swift */,
+				F438657822B22DCA001E50BE /* CommunicatorResponse.swift */,
 			);
 			path = Communicator;
 			sourceTree = "<group>";
@@ -87,6 +92,7 @@
 		F4E2480722998A0D004DD390 /* Transporter */ = {
 			isa = PBXGroup;
 			children = (
+				F438657A22B22DD9001E50BE /* TransportationResult.swift */,
 				F4E24802229951EE004DD390 /* Transporter.swift */,
 				F4E2480822998A28004DD390 /* URLSession+Transporter.swift */,
 			);
@@ -188,11 +194,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				F4CA9F4C2281D0D9000CD820 /* Communicator.swift in Sources */,
+				F438657922B22DCA001E50BE /* CommunicatorResponse.swift in Sources */,
 				F4E24803229951EE004DD390 /* Transporter.swift in Sources */,
 				F4E2480922998A28004DD390 /* URLSession+Transporter.swift in Sources */,
 				F4CA9F452281CEAE000CD820 /* DataUnpacker.swift in Sources */,
 				F4CA9F502281D429000CD820 /* APICommunicator.swift in Sources */,
 				F4CA9F522281D557000CD820 /* Logger.swift in Sources */,
+				F438657B22B22DD9001E50BE /* TransportationResult.swift in Sources */,
 				F4E24805229989E6004DD390 /* Cancellable.swift in Sources */,
 				F4CA9F542281D6A9000CD820 /* RequestBuilder.swift in Sources */,
 				F4CA9F412281CDA0000CD820 /* Endpoint.swift in Sources */,

--- a/Sources/Endpoints/Communicator/Communicator.swift
+++ b/Sources/Endpoints/Communicator/Communicator.swift
@@ -17,12 +17,6 @@ public protocol Communicator {
         ) -> Cancellable? where E: Endpoint
 }
 
-public struct CommunicatorResponse<Body> {
-    public let headers: [AnyHashable: Any]
-    public let code: Int
-    public let body: Body
-}
-
 public enum CommunicatorError: Error {
     case invalidURL
     case unacceptableStatusCode(ErrorReason)

--- a/Sources/Endpoints/Communicator/CommunicatorResponse.swift
+++ b/Sources/Endpoints/Communicator/CommunicatorResponse.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 public struct CommunicatorResponse<Body> {
-    public let headers: [AnyHashable: Any]
-    public let code: Int
     public let body: Body
+    public let code: Int
+    public let headers: [AnyHashable: Any]
 
-    public init(headers: [AnyHashable: Any] = [:], code: Int, body: Body) {
-        self.headers = headers
-        self.code = code
+    public init(body: Body, code: Int, headers: [AnyHashable: Any] = [:]) {
         self.body = body
+        self.code = code
+        self.headers = headers
     }
 }

--- a/Sources/Endpoints/Communicator/CommunicatorResponse.swift
+++ b/Sources/Endpoints/Communicator/CommunicatorResponse.swift
@@ -1,0 +1,20 @@
+//
+//  CommunicatorResponse.swift
+//  Endpoints
+//
+//  Created by Simon Jarbrant on 2019-06-13.
+//
+
+import Foundation
+
+public struct CommunicatorResponse<Body> {
+    public let headers: [AnyHashable: Any]
+    public let code: Int
+    public let body: Body
+
+    public init(headers: [AnyHashable: Any] = [:], code: Int, body: Body) {
+        self.headers = headers
+        self.code = code
+        self.body = body
+    }
+}

--- a/Sources/Endpoints/ResponseParser.swift
+++ b/Sources/Endpoints/ResponseParser.swift
@@ -25,9 +25,9 @@ public struct ResponseParser<Unpacker: DataUnpacker> {
         case HTTPURLResponse.successfulStatusCode:
             let decodedData = try unpacker.unpack(data)
             let response = CommunicatorResponse(
-                headers: response.allHeaderFields,
+                body: decodedData,
                 code: response.statusCode,
-                body: decodedData)
+                headers: response.allHeaderFields)
 
             return response
 

--- a/Sources/Endpoints/Transporter/TransportationResult.swift
+++ b/Sources/Endpoints/Transporter/TransportationResult.swift
@@ -1,0 +1,18 @@
+//
+//  TransportationResult.swift
+//  Endpoints
+//
+//  Created by Simon Jarbrant on 2019-06-13.
+//
+
+import Foundation
+
+public struct TransportationResult {
+    public let response: HTTPURLResponse
+    public let data: Data
+
+    public init(response: HTTPURLResponse, data: Data) {
+        self.response = response
+        self.data = data
+    }
+}

--- a/Sources/Endpoints/Transporter/Transporter.swift
+++ b/Sources/Endpoints/Transporter/Transporter.swift
@@ -1,6 +1,6 @@
 //
 //  Transporter.swift
-//  Endpoints iOS
+//  Endpoints
 //
 //  Created by Simon Jarbrant on 2019-05-25.
 //
@@ -9,9 +9,4 @@ import Foundation
 
 public protocol Transporter {
     func send(_ request: URLRequest, completionHandler: @escaping (Result<TransportationResult, Error>) -> Void) -> Cancellable
-}
-
-public struct TransportationResult {
-    let response: HTTPURLResponse
-    let data: Data
 }

--- a/Sources/Endpoints/Transporter/URLSession+Transporter.swift
+++ b/Sources/Endpoints/Transporter/URLSession+Transporter.swift
@@ -1,6 +1,6 @@
 //
 //  URLSession+Transporter.swift
-//  Endpoints iOS
+//  Endpoints
 //
 //  Created by Simon Jarbrant on 2019-05-25.
 //


### PR DESCRIPTION
Synthesised `struct` constructors are seemingly not public by default, causing our `CommunicatorResponse` and `TransportationResult` types to not be constructable from projects using Endpoints as a dependency. This effectively prohibits custom implementations of the `Communicator` and `Transporter` protocols, making testing _very_ difficult.

This PR solves those issues by exposing public constructors for the two types.